### PR TITLE
feat(scanner): add ratelimit

### DIFF
--- a/cmd/redis-ttl/config.go
+++ b/cmd/redis-ttl/config.go
@@ -8,13 +8,17 @@ import (
 	"time"
 )
 
-var errTTL = errors.New("invalid ttl")
+var (
+	errTTL = errors.New("invalid ttl")
+	errRPS = errors.New("invalid rps")
+)
 
 var defaultConfig = config{
 	redisAddr:  ":6379",
 	mode:       "noop",
 	scanPrefix: "not-found",
 	desiredTTL: ttl{dur: 1 * time.Hour},
+	rps:        100,
 }
 
 type config struct {
@@ -22,13 +26,17 @@ type config struct {
 	scanPrefix string
 	mode       string
 	desiredTTL ttl
+	rps        int
 }
 
 func (c *config) Err() error {
 	switch {
 	case c.desiredTTL.dur <= 0 && c.mode != "persist":
 		return fmt.Errorf("invalid desired-ttl value (%s) for mode %s: %w", &c.desiredTTL, c.mode, errTTL)
+	case c.rps <= 0:
+		return fmt.Errorf("rps must be greater than 0, got %d: %w", &c.rps, errRPS)
 	}
+
 	return nil
 }
 

--- a/cmd/redis-ttl/config_test.go
+++ b/cmd/redis-ttl/config_test.go
@@ -80,6 +80,10 @@ func TestConfig(t *testing.T) {
 			},
 			err: errTTL,
 		},
+		"can't set rps to 0": {
+			cfg: config{rps: 0, mode: "persist"},
+			err: errRPS,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.1
 require (
 	github.com/alicebob/miniredis/v2 v2.32.1
 	github.com/redis/go-redis/v9 v9.5.1
+	golang.org/x/time v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -18,3 +18,5 @@ github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
+golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=


### PR DESCRIPTION
Adds a new `--rps` flag which controls how many redis commands the scanner will execute. This helps not overwhelm replicas with expire/persist commands.