### PR TITLE
[feat] add support for specifying redis cluster addresses

### DIFF
--- a/cmd/redis-ttl/config.go
+++ b/cmd/redis-ttl/config.go
@@ -11,23 +11,27 @@ import (
 var errTTL = errors.New("invalid ttl")
 
 var defaultConfig = config{
-	redisAddr:  ":6379",
-	mode:       "noop",
-	scanPrefix: "not-found",
-	desiredTTL: ttl{dur: 1 * time.Hour},
+	redisAddr:         ":6379",
+	mode:              "noop",
+	scanPrefix:        "not-found",
+	desiredTTL:        ttl{dur: 1 * time.Hour},
+	redisClusterAddrs: "",
 }
 
 type config struct {
-	redisAddr  string
-	scanPrefix string
-	mode       string
-	desiredTTL ttl
+	redisAddr         string
+	scanPrefix        string
+	mode              string
+	desiredTTL        ttl
+	redisClusterAddrs string
 }
 
 func (c *config) Err() error {
 	switch {
 	case c.desiredTTL.dur <= 0 && c.mode != "persist":
 		return fmt.Errorf("invalid desired-ttl value (%s) for mode %s: %w", &c.desiredTTL, c.mode, errTTL)
+	case c.redisAddr == "" && c.redisClusterAddrs == "":
+		return fmt.Errorf("both --redis-addr and --redis-cluster-addrs cannot be empty")
 	}
 	return nil
 }

--- a/cmd/redis-ttl/main.go
+++ b/cmd/redis-ttl/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"strings"
 
 	redisttl "github.com/pims/redis-ttl"
 	"github.com/redis/go-redis/v9"
@@ -24,11 +25,11 @@ func run(args []string) error {
 
 	fs := flag.NewFlagSet("redis-ttl", flag.ExitOnError)
 
-	fs.StringVar(&cfg.redisAddr, "redis-addr", ":6379", "--redis-addr=:6379")
+	fs.StringVar(&cfg.redisAddr, "redis-addr", "", "--redis-addr=:6379")
 	fs.StringVar(&cfg.scanPrefix, "scan-prefix", "not-found", "--scan-prefix=my-prefix")
 	fs.StringVar(&cfg.mode, "mode", "noop", "--mode=exp|gt|lt|nx|xx|noop|persist")
 	fs.TextVar(&cfg.desiredTTL, "desired-ttl", &cfg.desiredTTL, "--desired-ttl=24h")
-
+	fs.StringVar(&cfg.redisClusterAddrs, "redis-cluster-addrs", "", "--redis-cluster-addrs=node1:6379,node2:6379")
 	if err := fs.Parse(args[1:]); err != nil {
 		return err
 	}
@@ -37,10 +38,18 @@ func run(args []string) error {
 		return err
 	}
 
-	// TODO: add support for redis cluster
-	rdb := redis.NewClient(&redis.Options{
-		Addr: cfg.redisAddr,
+	var rdb redis.Cmdable
+	rdb = redis.NewClient(&redis.Options{
+		Addr:       cfg.redisAddr,
+		ClientName: "redis-ttl",
 	})
+
+	if cfg.redisClusterAddrs != "" {
+		rdb = redis.NewClusterClient(&redis.ClusterOptions{
+			Addrs:      strings.Split(cfg.redisClusterAddrs, ","),
+			ClientName: "redis-ttl-cluster",
+		})
+	}
 
 	if _, err := rdb.Ping(context.Background()).Result(); err != nil {
 		return err


### PR DESCRIPTION
This is useful if the proxy in front of Redis Cluster does not support the scan command (ex: Envoy)