### PR TITLE
[feat] specify which types of keys are returned by the scan

### DIFF
--- a/cmd/redis-ttl/config.go
+++ b/cmd/redis-ttl/config.go
@@ -20,6 +20,7 @@ var defaultConfig = config{
 	desiredTTL:        ttl{dur: 1 * time.Hour},
 	rps:               100,
 	redisClusterAddrs: "",
+	scanType:          "string",
 }
 
 type config struct {
@@ -29,6 +30,7 @@ type config struct {
 	desiredTTL        ttl
 	rps               int
 	redisClusterAddrs string
+	scanType          string
 }
 
 func (c *config) Err() error {

--- a/cmd/redis-ttl/main.go
+++ b/cmd/redis-ttl/main.go
@@ -32,6 +32,7 @@ func run(args []string) error {
 	fs.TextVar(&cfg.desiredTTL, "desired-ttl", &cfg.desiredTTL, "--desired-ttl=24h")
 	fs.IntVar(&cfg.rps, "rps", 100, "--rps=100")
 	fs.StringVar(&cfg.redisClusterAddrs, "redis-cluster-addrs", "", "--redis-cluster-addrs=node1:6379,node2:6379")
+	fs.StringVar(&cfg.scanType, "scan-type", "string", "--scan-type=set|string|list|hash")
 
 	if err := fs.Parse(args[1:]); err != nil {
 		return err
@@ -64,6 +65,7 @@ func run(args []string) error {
 		Mode:       cfg.mode,
 		DesiredTTL: cfg.desiredTTL.AsDuration(),
 		Limiter:    rate.NewLimiter(rate.Limit(cfg.rps), cfg.rps),
+		ScanType:   cfg.scanType,
 	}
 
 	return f.Run(context.Background())

--- a/redis.go
+++ b/redis.go
@@ -22,11 +22,12 @@ type Scanner struct {
 	ScanPrefix string
 	DesiredTTL time.Duration
 	Limiter    limiter
+	ScanType   string
 }
 
 func (f *Scanner) Run(ctx context.Context) error {
 	c := f.Client
-	iter := c.Scan(ctx, 0, f.ScanPrefix, 0).Iterator()
+	iter := c.ScanType(ctx, 0, f.ScanPrefix, 0, f.ScanType).Iterator()
 
 	type ttlFunc func(ctx context.Context, key string, ttl time.Duration) *redis.BoolCmd
 


### PR DESCRIPTION
This change gives us the ability to all scan string keys for instance, and ignore all other types that also match the prefix.